### PR TITLE
add-bt34

### DIFF
--- a/lib/xrechnung.rb
+++ b/lib/xrechnung.rb
@@ -287,7 +287,7 @@ module Xrechnung
         "xmlns:cbc"          => "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
         "xmlns:xsi"          => "http://www.w3.org/2001/XMLSchema-instance",
         "xsi:schemaLocation" => "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd" do
-        xml.cbc :CustomizationID, "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_3.0"
+        xml.cbc :CustomizationID, "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2"
         xml.cbc :ID, id
         xml.cbc :IssueDate, issue_date
         xml.cbc :DueDate, due_date

--- a/lib/xrechnung.rb
+++ b/lib/xrechnung.rb
@@ -286,7 +286,7 @@ module Xrechnung
         "xmlns:cbc"          => "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
         "xmlns:xsi"          => "http://www.w3.org/2001/XMLSchema-instance",
         "xsi:schemaLocation" => "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd" do
-        xml.cbc :CustomizationID, "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2"
+        xml.cbc :CustomizationID, "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_3.0"
         xml.cbc :ID, id
         xml.cbc :IssueDate, issue_date
         xml.cbc :DueDate, due_date

--- a/lib/xrechnung.rb
+++ b/lib/xrechnung.rb
@@ -1,6 +1,7 @@
 require "xrechnung/version"
 require "date"
 require "xrechnung/currency"
+require "xrechnung/endpoint"
 require "xrechnung/quantity"
 require "xrechnung/id"
 require "xrechnung/member_container"

--- a/lib/xrechnung/endpoint.rb
+++ b/lib/xrechnung/endpoint.rb
@@ -1,0 +1,7 @@
+module Xrechnung
+  Endpoint = Struct.new(:electronic_address, :scheme) do
+    def xml_args
+      [electronic_address, schemeID: scheme]
+    end
+  end
+end

--- a/lib/xrechnung/party.rb
+++ b/lib/xrechnung/party.rb
@@ -9,7 +9,7 @@ module Xrechnung
 
     # @!attribute endpoint
     #   @return [String]
-    member :endpoint, type: Xrechnung::Endpoint
+    member :endpoint, type: Xrechnung::Id, optional: true
 
     # @!attribute postal_address
     #   @return [Xrechnung::PostalAddress]
@@ -42,8 +42,8 @@ module Xrechnung
     def to_xml(xml)
       if nested
         xml.cac :Party do
-          if endpoint.electronic_address.present?
-            xml.cbc :EndpointID, *endpoint.xml_args
+          unless endpoint.nil?
+            xml.cbc :EndpointID, endpoint.id, schemeID: endpoint.scheme_id
           end
           party_body(xml)
         end

--- a/lib/xrechnung/party.rb
+++ b/lib/xrechnung/party.rb
@@ -7,9 +7,9 @@ module Xrechnung
     member :name, type: String
 
 
-    # @!attribute electronic_mail
+    # @!attribute endpoint
     #   @return [String]
-    member :electronic_mail, type: String
+    member :endpoint, type: Xrechnung::Endpoint
 
     # @!attribute postal_address
     #   @return [Xrechnung::PostalAddress]
@@ -42,6 +42,9 @@ module Xrechnung
     def to_xml(xml)
       if nested
         xml.cac :Party do
+          if endpoint.electronic_address.present?
+            xml.cbc :EndpointID, *endpoint.xml_args
+          end
           party_body(xml)
         end
       else
@@ -59,7 +62,6 @@ module Xrechnung
           else
             xml.cbc :Name, name
           end
-          xml.cbc :ElectronicMail, electronic_mail # no idea if this is correct
         end
       end
 

--- a/lib/xrechnung/party.rb
+++ b/lib/xrechnung/party.rb
@@ -6,6 +6,11 @@ module Xrechnung
     #   @return [String]
     member :name, type: String
 
+
+    # @!attribute electronic_mail
+    #   @return [String]
+    member :electronic_mail, type: String
+
     # @!attribute postal_address
     #   @return [Xrechnung::PostalAddress]
     member :postal_address, type: Xrechnung::PostalAddress
@@ -54,8 +59,10 @@ module Xrechnung
           else
             xml.cbc :Name, name
           end
+          xml.cbc :ElectronicMail, electronic_mail # no idea if this is correct
         end
       end
+
       party_identification&.to_xml(xml)
       postal_address&.to_xml(xml)
       party_tax_scheme&.to_xml(xml)

--- a/lib/xrechnung/version.rb
+++ b/lib/xrechnung/version.rb
@@ -1,3 +1,3 @@
 module Xrechnung
-  VERSION = "0.1.27"
+  VERSION = "0.1.28"
 end

--- a/lib/xrechnung/version.rb
+++ b/lib/xrechnung/version.rb
@@ -1,3 +1,3 @@
 module Xrechnung
-  VERSION = "0.1.28"
+  VERSION = "0.1.29"
 end


### PR DESCRIPTION
this PR tries to implement

https://www.notion.so/projo-berlin/X-Rechnung-F-r-die-Abrechnung-bei-der-Deutschen-Bahn-wird-zwingend-das-Feld-BT-34-Antwortadresse-f--127261ae4d0a80d88da2c68829ac9e7a

I have no idea of xrechnungen and looked now the first time in it and find it very strange.

The specification on page 68 explains BT-34
https://xeinkauf.de/app/uploads/2023/02/231-XRechnung-2023-02-03.pdf

<img width="606" alt="image" src="https://github.com/user-attachments/assets/5e4f2945-f7c7-4342-b921-0c206c6c99fc">

This PR is a prerequisite for 
https://github.com/projo-berlin/projo/pull/9761
